### PR TITLE
add authentication to the fetch tokens from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `region` *string* Cognito UserPool region (eg: `us-east-1`)
   * `userPoolId` *string* Cognito UserPool ID (eg: `us-east-1_tyo1a1FHH`)
   * `userPoolAppId` *string* Cognito UserPool Application ID (eg: `63gcbm2jmskokurt5ku9fhejc6`)
+  * `userPoolAppSecret` *string* Cognito UserPool Application Secret (eg: `oh470px2i0uvy4i2ha6sju0vxe4ata9ol3m63ufhs2t8yytwjn7p`)
   * `userPoolDomain` *string* Cognito UserPool domain (eg: `your-domain.auth.us-east-1.amazoncognito.com`)
   * `cookieExpirationDays` *number* (Optional) Number of day to set cookies expiration date, default to 365 days (eg: `365`)
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `region` *string* Cognito UserPool region (eg: `us-east-1`)
   * `userPoolId` *string* Cognito UserPool ID (eg: `us-east-1_tyo1a1FHH`)
   * `userPoolAppId` *string* Cognito UserPool Application ID (eg: `63gcbm2jmskokurt5ku9fhejc6`)
-  * `userPoolAppSecret` *string* Cognito UserPool Application Secret (eg: `oh470px2i0uvy4i2ha6sju0vxe4ata9ol3m63ufhs2t8yytwjn7p`)
+  * `userPoolAppSecret` *string* (Optional) Cognito UserPool Application Secret (eg: `oh470px2i0uvy4i2ha6sju0vxe4ata9ol3m63ufhs2t8yytwjn7p`)
   * `userPoolDomain` *string* Cognito UserPool domain (eg: `your-domain.auth.us-east-1.amazoncognito.com`)
   * `cookieExpirationDays` *number* (Optional) Number of day to set cookies expiration date, default to 365 days (eg: `365`)
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ class Authenticator {
     this._region = params.region;
     this._userPoolId = params.userPoolId;
     this._userPoolAppId = params.userPoolAppId;
+    this._userPoolAppSecret = params.userPoolAppSecret;
     this._userPoolDomain = params.userPoolDomain;
     this._cookieExpirationDays = params.cookieExpirationDays || 365;
 
@@ -81,10 +82,14 @@ class Authenticator {
    * @return {Promise} Authenticated user tokens.
    */
   _fetchTokensFromCode(redirectURI, code) {
+    const authorization = this._userPoolAppSecret && Buffer.from(`${this._userPoolAppId}:${this._userPoolAppSecret}`).toString('base64');
     const request = {
       url: `https://${this._userPoolDomain}/oauth2/token`,
       method: 'post',
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...(authorization && {'Authorization': `Basic ${authorization}`}),
+      },
       data: querystring.stringify({
         client_id:	this._userPoolAppId,
         code:	code,


### PR DESCRIPTION
Issue #7 

 - allow cognito app with secret in case that the cognito app has a secret
 - app secret can now be received in params as `userPoolAppSecret`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.