### PR TITLE
added optional disableCookieDomain parameter (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `userPoolAppSecret` *string* (Optional) Cognito UserPool Application Secret (eg: `oh470px2i0uvy4i2ha6sju0vxe4ata9ol3m63ufhs2t8yytwjn7p`)
   * `userPoolDomain` *string* Cognito UserPool domain (eg: `your-domain.auth.us-east-1.amazoncognito.com`)
   * `cookieExpirationDays` *number* (Optional) Number of day to set cookies expiration date, default to 365 days (eg: `365`)
+  * `disableCookieDomain` *boolean* (Optional) Sets domain attribute in cookies, defaults to false (eg: `false`)
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
 
 *This is the class constructor.*


### PR DESCRIPTION
    * add disable cookie domain attribute as optional
     - in case app needs to exclude domain attribute
       which is more restrictive (ie. not allow subdomains)
     - defaults to false to maintain backwards compatibility
        (ie. include domain if false or not specified).

    * add (Optional) to the disableCookieDomain param documentation

*Issue # (if available):*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.