### PR TITLE
Use aws-jwt-verify to verify JSON Web Tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "aws-jwt-verify": "^1.0.1",
     "axios": "^0.21.1",
-    "jsonwebtoken": "^8.2.1",
-    "jwk-to-pem": "^2.0.4",
     "pino": "^6.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue # (if available):* N/A

*Description of changes:* AWS released a JWT verification library (disclaimer: I'm one of the main authors of that). This PR removes the dependency on `jsonwebtoken` and `jwk-to-pem` and instead uses the AWS JWT verification library: https://github.com/awslabs/aws-jwt-verify

Since that library has more built-in features (such as downloading and caching JWKS) I was able to remove quite a few lines from the lib here, because it has less to do now (which is good right). Test coverage has stayed the same (I notice there's a few lines of coding missing coverage, as they already did before)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.