### PR TITLE
Add cache-control & pragma headers to redirect responses

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -293,10 +293,18 @@ describe('handle', () => {
       {
         status: 302,
         headers: {
-          location: [{
+          'location': [{
             key: 'Location',
             value: 'https://my-cognito-domain.auth.us-east-1.amazoncognito.com/authorize?redirect_uri=https://d111111abcdef8.cloudfront.net&response_type=code&client_id=123456789qwertyuiop987abcd&state=/lol%3F%3Fparam%3D1',
           }],
+          'cache-control': [{
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, max-age=0, must-revalidate'
+          }],
+          'pragma': [{
+            key: 'Pragma',
+            value: 'no-cache'
+          }]
         },
       },
     )

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -162,7 +162,7 @@ describe('createAuthenticator', () => {
       userPoolAppId: '123456789qwertyuiop987abcd',
       userPoolDomain: 'my-cognito-domain.auth.us-east-1.amazoncognito.com',
       cookieExpirationDays: 365,
-      disableCookieDomain: true
+      disableCookieDomain: true,
     };
   });
 
@@ -299,12 +299,12 @@ describe('handle', () => {
           }],
           'cache-control': [{
             key: 'Cache-Control',
-            value: 'no-cache, no-store, max-age=0, must-revalidate'
+            value: 'no-cache, no-store, max-age=0, must-revalidate',
           }],
           'pragma': [{
             key: 'Pragma',
-            value: 'no-cache'
-          }]
+            value: 'no-cache',
+          }],
         },
       },
     )

--- a/index.js
+++ b/index.js
@@ -129,7 +129,18 @@ class Authenticator {
     const response = {
       status: '302' ,
       headers: {
-        'location': [{ key: 'Location', 'value': location }],
+        'location': [{ 
+          key: 'Location',
+           value: location
+        }],
+        'cache-control': [{
+          key: 'Cache-Control',
+          value: 'no-cache, no-store, max-age=0, must-revalidate'
+        }],
+        'pragma': [{
+          key: 'Pragma',
+          value: 'no-cache'
+        }],
         'set-cookie': [
           {
             key: 'Set-Cookie',
@@ -222,10 +233,18 @@ class Authenticator {
         return {
           status: 302,
           headers: {
-            location: [{
+            'location': [{
               key: 'Location',
               value: userPoolUrl,
             }],
+            'cache-control': [{
+              key: 'Cache-Control',
+              value: 'no-cache, no-store, max-age=0, must-revalidate'
+            }],
+            'pragma': [{
+              key: 'Pragma',
+              value: 'no-cache'
+            }]
           },
         };
       }

--- a/index.js
+++ b/index.js
@@ -131,15 +131,15 @@ class Authenticator {
       headers: {
         'location': [{ 
           key: 'Location',
-           value: location
+          value: location,
         }],
         'cache-control': [{
           key: 'Cache-Control',
-          value: 'no-cache, no-store, max-age=0, must-revalidate'
+          value: 'no-cache, no-store, max-age=0, must-revalidate',
         }],
         'pragma': [{
           key: 'Pragma',
-          value: 'no-cache'
+          value: 'no-cache',
         }],
         'set-cookie': [
           {
@@ -239,12 +239,12 @@ class Authenticator {
             }],
             'cache-control': [{
               key: 'Cache-Control',
-              value: 'no-cache, no-store, max-age=0, must-revalidate'
+              value: 'no-cache, no-store, max-age=0, must-revalidate',
             }],
             'pragma': [{
               key: 'Pragma',
-              value: 'no-cache'
-            }]
+              value: 'no-cache',
+            }],
           },
         };
       }


### PR DESCRIPTION
*Issue # (if available):* https://github.com/awslabs/cognito-at-edge/issues/18

*Description of changes:*
Add cache-control and pragma headers to 302 responses. This is my first time opening a PR for an OS project. I'd suggest updating the package version to 1.2 as well. Apologies, as I'm not sure if that's something I should do in the PR submission or if that is done at the time of merge. Let me know if any update is required. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.