### PR TITLE
Fix for double query params decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ class Authenticator {
       this._logger.debug("User isn't authenticated: %s", err);
       if (requestParams.code) {
         return this._fetchTokensFromCode(redirectURI, requestParams.code)
-          .then(tokens => this._getRedirectResponse(tokens, cfDomain, decodeURIComponent(requestParams.state)));
+          .then(tokens => this._getRedirectResponse(tokens, cfDomain, requestParams.state));
       } else {
         let redirectPath = request.uri;
         if (request.querystring && request.querystring !== '') {


### PR DESCRIPTION
*Issue #23

Removed the double decoding of the query params, on line 166 we already call `querystring.parse `method which does decoding by default according to Node Js [doc](https://nodejs.org/api/querystring.html#querystringparsestr-sep-eq-options), so there is no need to call `decodeURIComponent` on line 180.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.