### PR TITLE
Add typescript support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,10 +5,15 @@
     "amd": true,
     "jest": true
   },
-  "extends": "eslint:recommended",
-  "parserOptions": {
-    "ecmaVersion": 2018
-  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "rules": {
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ package-lock.json
 output-template.yml
 *.tgz
 coverage/
+dist/
+.DS_Store

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 
 jest.mock('axios');
 
-const { Authenticator } = require('../index');
+const { Authenticator } = require('../dist/index');
 
 const DATE = new Date('2017');
 global.Date = class extends Date {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,10 +1,11 @@
-const axios = require('axios');
+import axios from 'axios';
 
 jest.mock('axios');
 
-const { Authenticator } = require('../dist/index');
+import { Authenticator } from '../src/';
 
 const DATE = new Date('2017');
+// @ts-ignore
 global.Date = class extends Date {
   constructor() {
     super();
@@ -28,7 +29,7 @@ describe('private functions', () => {
   });
 
   test('should fetch token', () => {
-    axios.request.mockResolvedValue({ data: tokenData });
+    axios.request = jest.fn().mockResolvedValue({ data: tokenData });
 
     return authenticator._fetchTokensFromCode('htt://redirect', 'AUTH_CODE')
       .then(res => {
@@ -37,7 +38,7 @@ describe('private functions', () => {
   });
 
   test('should throw if unable to fetch token', () => {
-    axios.request.mockRejectedValue(new Error('Unexpected error'));
+    axios.request = jest.fn().mockRejectedValue(new Error('Unexpected error'));
     return expect(() => authenticator._fetchTokensFromCode('htt://redirect', 'AUTH_CODE')).rejects.toThrow();
   });
 
@@ -152,7 +153,9 @@ describe('createAuthenticator', () => {
   });
 
   test('should fail when creating authenticator without params', () => {
-    expect(() => new Authenticator()).toThrow('Expected params');
+    // @ts-ignore 
+    // ts-ignore is used here to override typescript's type check in the constructor
+    // this test is still useful when the library is imported to a js file 
     expect(() => new Authenticator()).toThrow('Expected params');
   });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.89",
+    "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "eslint": "^7.32.0",
-    "jest": "^26.6.3",
+    "jest": "^27.4.7",
+    "ts-jest": "^27.1.2",
     "typescript": "^4.5.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "description": "Cognito authentication made easy to protect your website with CloudFront and Lambda@Edge.",
   "author": "AWS Builder Labs <aws-builder-labs@amazon.com>",
   "license": "Apache-2.0",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "index.js"
+    "/dist"
   ],
   "scripts": {
+    "build": "tsc",
     "test": "jest --coverage"
   },
   "dependencies": {
@@ -21,8 +23,12 @@
     "pino": "^6.10.0"
   },
   "devDependencies": {
-    "eslint": "^7.17.0",
-    "jest": "^26.6.3"
+    "@types/aws-lambda": "^8.10.89",
+    "@typescript-eslint/eslint-plugin": "^5.9.1",
+    "@typescript-eslint/parser": "^5.9.1",
+    "eslint": "^7.32.0",
+    "jest": "^26.6.3",
+    "typescript": "^4.5.4"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "esnext",
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
*Issue #20* 

*Description of changes:*
- installed typescript dependency, added `tsconfig.json`
- moved `index.js` to `src/index.ts`, changed imports to typescript-style and fixed ts compiler errors
- added typings information to package.json
- adjusted eslint to work with typescript source and made sure there are no linting warnings or errors
- adjusted jest to be able to parse ts file in the new location and made sure all tests pass

*Other things to be considered:*
- with the current tsc configuration the js file will be generated in the `dist` folder and will not be available (like before - ready to use in the js format) in the project's root. I added `dist` to .gitignore, but if the previous behavior is desired, the `tsconfig.json` and `package.json` can of course be modified to reflect this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.