### PR TITLE
Add npmignore to include dist files in npm releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+output-template.yml
+*.tgz
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1](https://github.com/awslabs/cognito-at-edge/tree/1.2.1) (2022-01-17)
+
+[Full Changelog](https://github.com/awslabs/cognito-at-edge/compare/1.2.0...1.2.1)
+
 ## [1.2.0](https://github.com/awslabs/cognito-at-edge/tree/1.2.0) (2022-01-12)
 
 [Full Changelog](https://github.com/awslabs/cognito-at-edge/compare/1.1.1...1.2.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-at-edge",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/awslabs/cognito-at-edge"


### PR DESCRIPTION
*Issue # (if available):* n/a

*Description of changes:*
Adding a .npmignore file to include /dist files in future releases to npm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.