### PR TITLE
fix: update regex to account for idToken being last key value pair in cookie string

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -115,6 +115,13 @@ describe('private functions', () => {
         value: `CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.idToken=wrong; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}; CognitoIdentityServiceProvider.5ukasw8840tap1g1i1617jh8pi.${appClientName}.idToken=wrong;`,
       }]),
     ).toBe(tokenData.id_token);
+
+    expect(
+      authenticator._getIdTokenFromCookie([{
+        key: 'Cookie',
+        value: `CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.accessToken=someValue; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}`,
+      }]),
+    ).toBe(tokenData.id_token);
   });
 
   test('should getIdTokenFromCookie throw on cookies', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export class Authenticator {
   _getIdTokenFromCookie(cookies) {
     this._logger.debug({ msg: 'Extracting authentication token from request cookie', cookies });
     // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(`${this._userPoolAppId}\..+?\.idToken=(.*?);`);
+    const regex = new RegExp(`${this._userPoolAppId}\..+?\.idToken=(.*?)(?:;|$)`);
     if (cookies) {
       for (let i = 0; i < cookies.length; i++) {
         const matches = cookies[i].value.match(regex);


### PR DESCRIPTION
*Issue # (if available):*
n/a

*Description of changes:*

We found that the cookie's key-value pairs order matters for this class to work properly. If the idToken is the last cookie in the cookie string, then a `;` won't be added at the end of it. However, the Regex for extracting the idToken value currently expect this to always be there. 

This PR updates the RegEx to account for both matching a final `;` and for matching the end of the string value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.