### PR TITLE
feat: httpOnly param

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `userPoolDomain` *string* Cognito UserPool domain (eg: `your-domain.auth.us-east-1.amazoncognito.com`)
   * `cookieExpirationDays` *number* (Optional) Number of day to set cookies expiration date, default to 365 days (eg: `365`)
   * `disableCookieDomain` *boolean* (Optional) Sets domain attribute in cookies, defaults to false (eg: `false`)
+  * `httpOnly` *boolean* (Optional) Forbids JavaScript from accessing the cookies, defaults to false (eg: `false`). Note, if this is set to `true`, the cookies will not be accessible to Amplify auth if you are using it client side.
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
 
 *This is the class constructor.*


### PR DESCRIPTION
*Issue # (if available):*
None

*Description of changes:*

Adds `httpOnly` boolean property to Authenticator params. 
If `true` set cookies using [`HttpOnly`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).
These cookies can still be read from the request in the @edge lambda but are no longer available to javascript [Document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) API.

- adds httpOnly param
- conditionally sets cookies with `HttpOnly` 
- adds unit test
- updates README's param documentation


*Context*

This [issue discusses "Tokens exposed to users via cookies: security question"](https://github.com/awslabs/cognito-at-edge/issues/31) . It notes to avoid cookies you could  follow the authorization code grant flow - requiring a request to cognito to ensure code is valid each time.

> There is a tradeoff between latency and security. 

We'd like to avoid this extra call but also have additional security by setting the cookies using [`HttpOnly` as a way to mitigate attacks involving cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#security).

For our use case we don't need to use amplify on the frontend and this PR assumes support isn't a requirement? 
But it might be a bit confusing as the cookies are set with the prefix expected by amplify auth and the architecture diagram includes the amplify logo by the web app. Tried to avoid confusion by making it explicit in readme but happy for feedback on making this clearer if needed.

Thanks for reviewing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.