### PR TITLE
Encode illegal characters inside cookies and change cookies parsing logic

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 jest.mock('axios');
 
 import { Authenticator } from '../src/';
+import { Cookies } from '../src/util/cookie';
 
 const DATE = new Date('2017');
 // @ts-ignore
@@ -61,11 +62,11 @@ describe('private functions', () => {
       },
     });
     expect(response.headers['set-cookie']).toEqual(expect.arrayContaining([
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Domain=${domain}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Domain=${domain}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone email profile openid aws.cognito.signin.user.admin; Domain=${domain}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Domain=${domain}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Domain=${domain}; Expires=${DATE}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone%20email%20profile%20openid%20aws.cognito.signin.user.admin; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure`},
     ]));
     expect(authenticator._jwtVerifier.verify).toHaveBeenCalled();
   });
@@ -81,13 +82,13 @@ describe('private functions', () => {
       logLevel: 'error',
     });
     authenticatorWithNoCookieDomain._jwtVerifier.cacheJwks(jwksData);
-  
+
     const username = 'toto';
     const domain = 'example.com';
     const path = '/test';
     jest.spyOn(authenticatorWithNoCookieDomain._jwtVerifier, 'verify');
     authenticatorWithNoCookieDomain._jwtVerifier.verify.mockReturnValueOnce(Promise.resolve({ token_use: 'id', 'cognito:username': username }));
-  
+
     const response = await authenticatorWithNoCookieDomain._getRedirectResponse(tokenData, domain, path);
     expect(response).toMatchObject({
       status: '302',
@@ -99,11 +100,11 @@ describe('private functions', () => {
       },
     });
     expect(response.headers['set-cookie']).toEqual(expect.arrayContaining([
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone email profile openid aws.cognito.signin.user.admin; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Expires=${DATE}; Secure`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Expires=${DATE}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone%20email%20profile%20openid%20aws.cognito.signin.user.admin; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Expires=${DATE.toUTCString()}; Secure`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Expires=${DATE.toUTCString()}; Secure`},
     ]));
     expect(authenticatorWithNoCookieDomain._jwtVerifier.verify).toHaveBeenCalled();
   });
@@ -120,13 +121,13 @@ describe('private functions', () => {
       logLevel: 'error',
     });
     authenticatorWithHttpOnly._jwtVerifier.cacheJwks(jwksData);
-  
+
     const username = 'toto';
     const domain = 'example.com';
     const path = '/test';
     jest.spyOn(authenticatorWithHttpOnly._jwtVerifier, 'verify');
     authenticatorWithHttpOnly._jwtVerifier.verify.mockReturnValueOnce(Promise.resolve({ token_use: 'id', 'cognito:username': username }));
-  
+
     const response = await authenticatorWithHttpOnly._getRedirectResponse(tokenData, domain, path);
     expect(response).toMatchObject({
       status: '302',
@@ -138,11 +139,11 @@ describe('private functions', () => {
       },
     });
     expect(response.headers['set-cookie']).toEqual(expect.arrayContaining([
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Domain=${domain}; Expires=${DATE}; Secure; HttpOnly`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Domain=${domain}; Expires=${DATE}; Secure; HttpOnly`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone email profile openid aws.cognito.signin.user.admin; Domain=${domain}; Expires=${DATE}; Secure; HttpOnly`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Domain=${domain}; Expires=${DATE}; Secure; HttpOnly`},
-      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Domain=${domain}; Expires=${DATE}; Secure; HttpOnly`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.accessToken=${tokenData.access_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure; HttpOnly`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.refreshToken=${tokenData.refresh_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure; HttpOnly`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.tokenScopesString=phone%20email%20profile%20openid%20aws.cognito.signin.user.admin; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure; HttpOnly`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${username}.idToken=${tokenData.id_token}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure; HttpOnly`},
+      {key: 'Set-Cookie', value: `CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.LastAuthUser=${username}; Domain=${domain}; Expires=${DATE.toUTCString()}; Secure; HttpOnly`},
     ]));
     expect(authenticatorWithHttpOnly._jwtVerifier.verify).toHaveBeenCalled();
   });
@@ -152,21 +153,27 @@ describe('private functions', () => {
     expect(
       authenticator._getIdTokenFromCookie([{
         key: 'Cookie',
-        value: `CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.idToken=wrong; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}; CognitoIdentityServiceProvider.5ukasw8840tap1g1i1617jh8pi.${appClientName}.idToken=wrong;`,
+        value: [
+          Cookies.serialize(`CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.idToken`, 'wrong'),
+          Cookies.serialize(`CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken`, tokenData.id_token),
+          Cookies.serialize(`CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken`, tokenData.id_token),
+          Cookies.serialize(`CognitoIdentityServiceProvider.5ukasw8840tap1g1i1617jh8pi.${appClientName}.idToken`, 'wrong'),
+        ].join('; '),
       }]),
     ).toBe(tokenData.id_token);
 
     expect(
       authenticator._getIdTokenFromCookie([{
         key: 'Cookie',
-        value: `CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.accessToken=someValue; CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken=${tokenData.id_token}`,
+        value: [
+          Cookies.serialize(`CognitoIdentityServiceProvider.5uka3k8840tap1g1i1617jh8pi.${appClientName}.accessToken`, 'someValue'),
+          Cookies.serialize(`CognitoIdentityServiceProvider.123456789qwertyuiop987abcd.${appClientName}.idToken`, tokenData.id_token),
+        ].join('; '),
       }]),
     ).toBe(tokenData.id_token);
   });
 
   test('should getIdTokenFromCookie throw on cookies', () => {
-    expect(() => authenticator._getIdTokenFromCookie()).toThrow('Id token');
-    expect(() => authenticator._getIdTokenFromCookie('')).toThrow('Id token');
     expect(() => authenticator._getIdTokenFromCookie([])).toThrow('Id token');
   });
 });
@@ -199,16 +206,16 @@ describe('createAuthenticator', () => {
     delete params.disableCookieDomain;
     expect(typeof new Authenticator(params)).toBe('object');
   });
-  
+
   test('should create authenticator without httpOnly', () => {
     delete params.httpOnly;
     expect(typeof new Authenticator(params)).toBe('object');
   });
 
   test('should fail when creating authenticator without params', () => {
-    // @ts-ignore 
+    // @ts-ignore
     // ts-ignore is used here to override typescript's type check in the constructor
-    // this test is still useful when the library is imported to a js file 
+    // this test is still useful when the library is imported to a js file
     expect(() => new Authenticator()).toThrow('Expected params');
   });
 

--- a/__tests__/util/cookie.test.ts
+++ b/__tests__/util/cookie.test.ts
@@ -1,0 +1,99 @@
+import { CookieAttributes, Cookies } from '../../src/util/cookie';
+
+describe('parse tests', () => {
+  test('should parse valid cookie string', () => {
+    const cookieString = [
+      'test.cookie.one=test.value.one',
+      'test.cookie.two=test.value.two',
+    ].join(';');
+
+    expect(Cookies.parse(cookieString))
+      .toStrictEqual([
+        { name: 'test.cookie.one', value: 'test.value.one' },
+        { name: 'test.cookie.two', value: 'test.value.two' },
+      ]);
+  });
+
+  test('should parse valid cookie string with URI encoded characters', () => {
+    const cookieString = '%F0%9F%91%BB%28%29%3C%3E%40%2C%3B%3A%5C%22%2F%5B%5D%3F%3D%7B%7D%20=%20%22%2C%3B=%5C%F0%9F%91%BB';
+
+    expect(Cookies.parse(cookieString))
+      .toStrictEqual([
+        { name: '👻()<>@,;:\\"/[]?={} ', value: ' ",;=\\👻' },
+      ]);
+  });
+
+  test('should try to parse cookie even with not-encoded illegal characters', () => {
+    const cookieString = '(🤪)<>@,:\\"/[%1Y]?{}%=,\\%"; :=,\\%\\';
+
+    expect(Cookies.parse(cookieString))
+      .toStrictEqual([
+        { name: '(🤪)<>@,:\\"/[%1Y]?{}%', value: ',\\%"' },
+        { name: ':', value: ',\\%\\' },
+      ]);
+  });
+
+  test('should skip cookies without separator', () => {
+    const cookieString = [
+      '1.name=value',
+      'somestring',
+      '2.name=value',
+    ].join(';');
+
+    expect(Cookies.parse(cookieString))
+      .toStrictEqual([
+        { name: '1.name', value: 'value' },
+        { name: '2.name', value: 'value' },
+      ]);
+  });
+
+  test('should return empty array when input parameter is null', () => {
+    expect(Cookies.parse(null)).toStrictEqual([]);
+  });
+});
+
+describe('serialize tests', () => {
+  test('should correctly serialize cookie without attributes', () => {
+    expect(Cookies.serialize('name', 'value'))
+      .toStrictEqual('name=value');
+  });
+
+  test('should correctly serialize cookie with defined attributes', () => {
+    const attributes: CookieAttributes = {
+      domain: 'example.com',
+      path: '/path/path',
+      expires: new Date(0),
+      maxAge: 1,
+      secure: true,
+      httpOnly: true,
+    };
+
+    expect(Cookies.serialize('name', 'value', attributes))
+      .toStrictEqual('name=value; Domain=example.com; Path=/path/path; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=1; Secure; HttpOnly');
+  });
+
+  test('should skip undefined attributes on serialization', () => {
+    const attributes: CookieAttributes = {
+      domain: undefined,
+      maxAge: 1,
+      secure: true,
+      httpOnly: true,
+    };
+
+    expect(Cookies.serialize('name', 'value', attributes))
+      .toStrictEqual('name=value; Max-Age=1; Secure; HttpOnly');
+  });
+
+  test('should encode characters not compliant with RFC 6265 and correctly decode it on parse', () => {
+    const name = '\t(%)<>@,;🤪:\\"/[]?={ключ} ';
+    const value = ' ,<;>\t😉%=\\значение';
+
+    const serialized = Cookies.serialize(name, value);
+
+    expect(serialized)
+      .toStrictEqual('%09%28%25%29%3C%3E%40%2C%3B%F0%9F%A4%AA%3A%5C%22%2F%5B%5D%3F%3D%7B%D0%BA%D0%BB%D1%8E%D1%87%7D%20=%20%2C<%3B>%09%F0%9F%98%89%25=%5C%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D0%B5');
+
+    expect(Cookies.parse(serialized))
+      .toStrictEqual([{ name, value }]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,11 +175,11 @@ export class Authenticator {
     const token = cookies.find(c => c.name.startsWith(tokenCookieNamePrefix) && c.name.endsWith(tokenCookieNamePostfix))?.value;
 
     if (!token) {
-      this._logger.debug("  idToken wasn't present in request cookies");
-      throw new Error("Id token isn't present in the request cookies");
+      this._logger.debug("idToken wasn't present in request cookies");
+      throw new Error("idToken isn't present in the request cookies");
     }
 
-    this._logger.debug({ msg: '  Found token in cookie', token });
+    this._logger.debug({ msg: 'Found idToken in cookie', token });
     return token;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { parse, stringify } from 'querystring';
 import pino from 'pino';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import { CloudFrontRequestEvent, CloudFrontRequestResult } from 'aws-lambda';
+import { CookieAttributes, Cookies } from './util/cookie';
 
 interface AuthenticatorParams {
   region: string;
@@ -37,8 +38,8 @@ export class Authenticator {
     this._userPoolAppSecret = params.userPoolAppSecret;
     this._userPoolDomain = params.userPoolDomain;
     this._cookieExpirationDays = params.cookieExpirationDays || 365;
-    this._disableCookieDomain = ('disableCookieDomain' in params && params.disableCookieDomain === true) ? true : false;
-    this._httpOnly = ('httpOnly' in params && params.httpOnly === true) ? true : false;
+    this._disableCookieDomain = ('disableCookieDomain' in params && params.disableCookieDomain === true);
+    this._httpOnly = ('httpOnly' in params && params.httpOnly === true);
     this._cookieBase = `CognitoIdentityServiceProvider.${params.userPoolAppId}`;
     this._logger = pino({
       level: params.logLevel || 'silent', // Default to silent
@@ -121,17 +122,24 @@ export class Authenticator {
     const decoded = await this._jwtVerifier.verify(tokens.id_token);
     const username = decoded['cognito:username'];
     const usernameBase = `${this._cookieBase}.${username}`;
-    const directives = [
-      ...((this._disableCookieDomain) ? [] : [`Domain=${domain}`]),
-      `Expires=${new Date(Date.now() + this._cookieExpirationDays * 864e+5)}`,
-      'Secure',
-      ...((this._httpOnly) ? ['HttpOnly'] : []),
-    ].join('; ');
+    const cookieAttributes: CookieAttributes = {
+      domain: this._disableCookieDomain ? undefined : domain,
+      expires: new Date(Date.now() + this._cookieExpirationDays * 864e+5),
+      secure: true,
+      httpOnly: this._httpOnly,
+    };
+    const cookies = [
+      Cookies.serialize(`${usernameBase}.accessToken`, tokens.access_token, cookieAttributes),
+      Cookies.serialize(`${usernameBase}.idToken`, tokens.id_token, cookieAttributes),
+      Cookies.serialize(`${usernameBase}.refreshToken`, tokens.refresh_token, cookieAttributes),
+      Cookies.serialize(`${usernameBase}.tokenScopesString`, 'phone email profile openid aws.cognito.signin.user.admin', cookieAttributes),
+      Cookies.serialize(`${this._cookieBase}.LastAuthUser`, username, cookieAttributes),
+    ];
 
     const response = {
       status: '302' ,
       headers: {
-        'location': [{ 
+        'location': [{
           key: 'Location',
           value: location,
         }],
@@ -143,28 +151,7 @@ export class Authenticator {
           key: 'Pragma',
           value: 'no-cache',
         }],
-        'set-cookie': [
-          {
-            key: 'Set-Cookie',
-            value: `${usernameBase}.accessToken=${tokens.access_token}; ${directives}`,
-          },
-          {
-            key: 'Set-Cookie',
-            value: `${usernameBase}.idToken=${tokens.id_token}; ${directives}`,
-          },
-          {
-            key: 'Set-Cookie',
-            value: `${usernameBase}.refreshToken=${tokens.refresh_token}; ${directives}`,
-          },
-          {
-            key: 'Set-Cookie',
-            value: `${usernameBase}.tokenScopesString=phone email profile openid aws.cognito.signin.user.admin; ${directives}`,
-          },
-          {
-            key: 'Set-Cookie',
-            value: `${this._cookieBase}.LastAuthUser=${username}; ${directives}`,
-          },
-        ],
+        'set-cookie': cookies.map(c => ({ key: 'Set-Cookie', value: c })),
       },
     };
 
@@ -175,24 +162,25 @@ export class Authenticator {
 
   /**
    * Extract value of the authentication token from the request cookies.
-   * @param  {Array}  cookies Request cookies.
+   * @param  {Array}  cookieHeaders 'Cookie' request headers.
    * @return {String} Extracted access token. Throw if not found.
    */
-  _getIdTokenFromCookie(cookies) {
-    this._logger.debug({ msg: 'Extracting authentication token from request cookie', cookies });
-    // eslint-disable-next-line no-useless-escape
-    const regex = new RegExp(`${this._userPoolAppId}\..+?\.idToken=(.*?)(?:;|$)`);
-    if (cookies) {
-      for (let i = 0; i < cookies.length; i++) {
-        const matches = cookies[i].value.match(regex);
-        if (matches && matches.length > 1) {
-          this._logger.debug({ msg: '  Found token in cookie', token: matches[1] });
-          return matches[1];
-        }
-      }
+  _getIdTokenFromCookie(cookieHeaders: Array<{ key?: string | undefined, value: string }>) {
+    this._logger.debug({ msg: 'Extracting authentication token from request cookie', cookieHeaders });
+
+    const tokenCookieNamePrefix = `${this._cookieBase}.`;
+    const tokenCookieNamePostfix = '.idToken';
+
+    const cookies = cookieHeaders.flatMap(h => Cookies.parse(h.value));
+    const token = cookies.find(c => c.name.startsWith(tokenCookieNamePrefix) && c.name.endsWith(tokenCookieNamePostfix))?.value;
+
+    if (!token) {
+      this._logger.debug("  idToken wasn't present in request cookies");
+      throw new Error("Id token isn't present in the request cookies");
     }
-    this._logger.debug("  idToken wasn't present in request cookies");
-    throw new Error("Id token isn't present in the request cookies");
+
+    this._logger.debug({ msg: '  Found token in cookie', token });
+    return token;
   }
 
   /**

--- a/src/util/cookie.ts
+++ b/src/util/cookie.ts
@@ -1,0 +1,130 @@
+
+export interface Cookie {
+    name: string;
+    value: string;
+}
+
+/**
+ * Cookie attributes to be used inside 'Set-Cookie' header
+ */
+export interface CookieAttributes {
+    /**
+     * The Domain attribute specifies those hosts to which the cookie will be sent.
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3 RFC 6265 section 4.1.2.3.} for more details.
+     */
+    domain?: string;
+
+    /**
+     * The Expires attribute indicates the maximum lifetime of the cookie, represented as the date and time at which
+     * the cookie expires.
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.1 RFC 6265 section 4.1.2.1.} for more details.
+     */
+    expires?: Date;
+
+    /**
+     * The HttpOnly attribute limits the scope of the cookie to HTTP requests.
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.6 RFC 6265 section 4.1.2.6.} for more details.
+     */
+    httpOnly?: boolean;
+
+    /**
+     * The Max-Age attribute indicates the maximum lifetime of the cookie, represented as the number of seconds until
+     * the cookie expires.
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.2 RFC 6265 section 4.1.2.2.} for more details.
+     */
+    maxAge?: number;
+
+    /**
+     * The scope of each cookie is limited to a set of paths, controlled by the Path attribute.
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.4 RFC 6265 section 4.1.2.4.} for more details.
+     */
+    path?: string;
+
+    /**
+     * The Secure attribute limits the scope of the cookie to "secure" channels (where "secure" is defined by the user agent).
+     * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.5 RFC 6265 section 4.1.2.5.} for more details.
+     */
+    secure?: boolean;
+}
+
+export class Cookies {
+
+  /**
+   * Parse `Cookie` header string compliant with RFC 6265 and decode URI encoded characters.
+   *
+   * @param cookiesString 'Cookie' header value
+   * @returns array of {@type Cookie} objects
+   */
+  static parse(cookiesString: string): Cookie[] {
+    const cookieStrArray = cookiesString ? cookiesString.split(';') : [];
+
+    const cookies: Cookie[] = [];
+
+    for (const cookieStr of cookieStrArray) {
+      const separatorIndex = cookieStr.indexOf('=');
+
+      if (separatorIndex < 0) {
+        continue;
+      }
+
+      const name = this.decodeName(cookieStr.substring(0, separatorIndex).trim());
+      const value = this.decodeValue(cookieStr.substring(separatorIndex + 1).trim());
+
+      cookies.push({ name, value });
+    }
+
+    return cookies;
+  }
+
+  /**
+   * Serialize a cookie name-value pair into a `Set-Cookie` header string and URI encode characters that doesn't comply
+   * with RFC 6265
+   *
+   * @param name cookie name
+   * @param value cookie value
+   * @param attributes cookie attributes
+   * @returns string to be used as `Set-Cookie` header
+   */
+  static serialize(name: string, value: string, attributes: CookieAttributes = {}): string {
+    return [
+      `${this.encodeName(name)}=${this.encodeValue(value)}`,
+      ...(attributes.domain ? [`Domain=${attributes.domain}`] : []),
+      ...(attributes.path ? [`Path=${attributes.path}`] : []),
+      ...(attributes.expires ? [`Expires=${attributes.expires.toUTCString()}`] : []),
+      ...(attributes.maxAge ? [`Max-Age=${attributes.maxAge}`] : []),
+      ...(attributes.secure ? ['Secure'] : []),
+      ...(attributes.httpOnly ? ['HttpOnly'] : []),
+    ].join('; ');
+  }
+
+  /**
+   * URI encodes all characters not compliant with RFC 6265 cookie-name syntax (namely, non-US-ASCII,
+   * control characters and `()<>@,;:\"/[]?={} `) as well as `%` character to enable URI encoding support.
+   * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1 RFC 6265 section 4.1.1.} for more details.
+   */
+  private static encodeName = (str: string) =>
+    str.replace(/[^\x21\x23\x24\x26\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5A\x5E-\x7A\x7C\x7E]+/g, encodeURIComponent)
+      .replace(/[()]/g, (s) => `%${s.charCodeAt(0).toString(16).toUpperCase()}`);
+
+  /**
+   * Safely URI decodes cookie name.
+   */
+  private static decodeName = (str: string) =>
+    str.replace(/(%[\dA-Fa-f]{2})+/g, decodeURIComponent);
+
+  /**
+   * URI encodes all characters not compliant with RFC 6265 cookie-octet syntax (namely, non-US-ASCII,
+   * control characters, whitespace, double quote, comma, semicolon and backslash) as well as `%` character
+   * to enable URI encoding support.
+   * Refer to {@link https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1 RFC 6265 section 4.1.1.} for more details.
+   */
+  private static encodeValue = (str: string) =>
+    str.replace(/[^\x21\x23\x24\x26-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+/g, encodeURIComponent);
+
+  /**
+   * Safely URI decodes cookie value.
+   */
+  private static decodeValue = (str: string) =>
+    str.replace(/(%[\dA-Fa-f]{2})+/g, decodeURIComponent);
+
+}


### PR DESCRIPTION
*Issue # (if available):*
#43 

*Description of changes:*
* Make produced cookies RFC 6265 compliant by URI encoding illegal characters.
* Revise cookies parsing logic to fix issues with subdomains (#43)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.