### PR TITLE
Improve types and type checks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "aws-jwt-verify": "^2.1.1",
     "axios": "^0.25.0",
-    "pino": "^6.10.0"
+    "pino": "^8.14.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.89",

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export class Authenticator {
    * @return Lambda@Edge response.
    */
   async _getRedirectResponse(tokens: Tokens, domain: string, location: string): Promise<CloudFrontResultResponse> {
-    const decoded = await this._jwtVerifier.verify(tokens.idToken);
+    const decoded = await this._jwtVerifier.verify(tokens.idToken as string);
     const username = decoded['cognito:username'] as string;
     const usernameBase = `${this._cookieBase}.${username}`;
     const cookieAttributes: CookieAttributes = {
@@ -190,8 +190,8 @@ export class Authenticator {
       path: this._cookiePath,
     };
     const cookies = [
-      Cookies.serialize(`${usernameBase}.accessToken`, tokens.accessToken, cookieAttributes),
-      Cookies.serialize(`${usernameBase}.idToken`, tokens.idToken, cookieAttributes),
+      Cookies.serialize(`${usernameBase}.accessToken`, tokens.accessToken as string, cookieAttributes),
+      Cookies.serialize(`${usernameBase}.idToken`, tokens.idToken as string, cookieAttributes),
       ...(tokens.refreshToken ? [Cookies.serialize(`${usernameBase}.refreshToken`, tokens.refreshToken, cookieAttributes)] : []),
       Cookies.serialize(`${usernameBase}.tokenScopesString`, 'phone email profile openid aws.cognito.signin.user.admin', cookieAttributes),
       Cookies.serialize(`${this._cookieBase}.LastAuthUser`, username, cookieAttributes),
@@ -311,7 +311,7 @@ export class Authenticator {
       const tokens = this._getTokensFromCookie(request.headers.cookie);
       this._logger.debug({ msg: 'Verifying token...', tokens });
       try {
-        const user = await this._jwtVerifier.verify(tokens.idToken);
+        const user = await this._jwtVerifier.verify(tokens.idToken as string);
         this._logger.info({ msg: 'Forwarding request', path: request.uri, user });
         return request;
       } catch (err) {
@@ -326,7 +326,7 @@ export class Authenticator {
     } catch (err) {
       this._logger.debug("User isn't authenticated: %s", err);
       if (requestParams.code) {
-        return this._fetchTokensFromCode(redirectURI, requestParams.code)
+        return this._fetchTokensFromCode(redirectURI, requestParams.code as string)
           .then(tokens => this._getRedirectResponse(tokens, cfDomain, requestParams.state as string));
       } else {
         return this._getRedirectToCognitoUserPoolResponse(request, redirectURI);

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export class Authenticator {
     if ('httpOnly' in params && typeof params.httpOnly !== 'boolean') {
       throw new Error('Expected params.httpOnly to be a boolean');
     }
-    if ('sameSite' in params && params.sameSite !== undefined && !SAME_SITE_VALUES.includes(params.sameSite)) {
+    if (params.sameSite !== undefined && !SAME_SITE_VALUES.includes(params.sameSite)) {
       throw new Error('Expected params.sameSite to be a Strict || Lax || None');
     }
     if ('cookiePath' in params && typeof params.cookiePath !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import pino from 'pino';
 import { parse, stringify } from 'querystring';
 import { CookieAttributes, Cookies, SameSite, SAME_SITE_VALUES } from './util/cookie';
 
-interface AuthenticatorParams {
+export interface AuthenticatorParams {
   region: string;
   userPoolId: string;
   userPoolAppId: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,9 @@ interface AuthenticatorParams {
 }
 
 interface Tokens {
-  accessToken?: string;
-  idToken?: string;
-  refreshToken?: string;
+    accessToken?: string;
+    idToken?: string;
+    refreshToken?: string;
 }
 
 export class Authenticator {
@@ -69,12 +69,12 @@ export class Authenticator {
    * @param  {object} params constructor params
    * @return {void} throw an exception if params are incorects.
    */
-  _verifyParams(params) {
+  _verifyParams(params: AuthenticatorParams) {
     if (typeof params !== 'object') {
       throw new Error('Expected params to be an object');
     }
     [ 'region', 'userPoolId', 'userPoolAppId', 'userPoolDomain' ].forEach(param => {
-      if (typeof params[param] !== 'string') {
+      if (typeof params[param as keyof AuthenticatorParams] !== 'string') {
         throw new Error(`Expected params.${param} to be a string`);
       }
     });
@@ -87,7 +87,7 @@ export class Authenticator {
     if ('httpOnly' in params && typeof params.httpOnly !== 'boolean') {
       throw new Error('Expected params.httpOnly to be a boolean');
     }
-    if ('sameSite' in params && !SAME_SITE_VALUES.includes(params.sameSite)) {
+    if ('sameSite' in params && params.sameSite !== undefined && !SAME_SITE_VALUES.includes(params.sameSite)) {
       throw new Error('Expected params.sameSite to be a Strict || Lax || None');
     }
     if ('cookiePath' in params && typeof params.cookiePath !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,9 @@ export interface AuthenticatorParams {
 }
 
 interface Tokens {
-    accessToken?: string;
-    idToken?: string;
-    refreshToken?: string;
+  accessToken?: string;
+  idToken?: string;
+  refreshToken?: string;
 }
 
 export class Authenticator {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,13 @@
     "module": "commonjs",
     "target": "esnext",
     "declaration": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "strict": true
   },
   "include": [
     "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": false
+  },
+}


### PR DESCRIPTION
*Description of changes:*

- `AuthenticatorParams` type is now exported, making it easier to typecheck params before passing them to the `handle` function
- The return type of the `handle` function has been narrowed to exclude `undefined` and `null`. 
- Pino dependency has been updated to a typed release
- Type casts have been made explicit
- Strict type checking has been enabled in the source files and explicitly disabled in the test files
