### PR TITLE
Add path to redirect url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -603,7 +603,8 @@ export class Authenticator {
     const { request } = event.Records[0].cf;
     const requestParams = parse(request.querystring);
     const cfDomain = request.headers.host[0].value;
-    const redirectURI = `https://${cfDomain}`;
+    const path = request.uri
+    const redirectURI = `https://${cfDomain}${path}`;
 
     try {
       const tokens = this._getTokensFromCookie(request.headers.cookie);
@@ -658,7 +659,8 @@ export class Authenticator {
     const { request } = event.Records[0].cf;
     const requestParams = parse(request.querystring);
     const cfDomain = request.headers.host[0].value;
-    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}`;
+    const path = request.uri
+    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}${path}`;
 
     try {
       const tokens = this._getTokensFromCookie(request.headers.cookie);
@@ -740,8 +742,9 @@ export class Authenticator {
 
     const { request } = event.Records[0].cf;
     const cfDomain = request.headers.host[0].value;
+    const path = request.uri
     const requestParams = parse(request.querystring);
-    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}`;
+    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}${path}`;
 
     try {
       let tokens = this._getTokensFromCookie(request.headers.cookie);

--- a/src/index.ts
+++ b/src/index.ts
@@ -603,8 +603,8 @@ export class Authenticator {
     const { request } = event.Records[0].cf;
     const requestParams = parse(request.querystring);
     const cfDomain = request.headers.host[0].value;
-    const path = request.uri
-    const redirectURI = `https://${cfDomain}${path}`;
+    const uriPath = request.uri
+    const redirectURI = (uriPath === "/") ? `https://${cfDomain}` : `https://${cfDomain}${uriPath}`;
 
     try {
       const tokens = this._getTokensFromCookie(request.headers.cookie);
@@ -659,9 +659,8 @@ export class Authenticator {
     const { request } = event.Records[0].cf;
     const requestParams = parse(request.querystring);
     const cfDomain = request.headers.host[0].value;
-    const path = request.uri
-    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}${path}`;
-
+    const uriPath = request.uri
+    const redirectURI = (uriPath === "/") ? `https://${cfDomain}` : `https://${cfDomain}${uriPath}`;
     try {
       const tokens = this._getTokensFromCookie(request.headers.cookie);
 
@@ -742,9 +741,9 @@ export class Authenticator {
 
     const { request } = event.Records[0].cf;
     const cfDomain = request.headers.host[0].value;
-    const path = request.uri
+    const uriPath = request.uri
     const requestParams = parse(request.querystring);
-    const redirectURI = requestParams.redirect_uri as string || `https://${cfDomain}${path}`;
+    const redirectURI = requestParams.redirect_uri as string || (uriPath === "/") ? `https://${cfDomain}` : `https://${cfDomain}${uriPath}`;
 
     try {
       let tokens = this._getTokensFromCookie(request.headers.cookie);
@@ -794,5 +793,9 @@ export class Authenticator {
       return this._clearCookies(event);
     }
   }
+}
+
+function stripTrailingSlash(input: string): string {
+  return input.replace(/\/$/, ''); // Remove trailing slash if it exists
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -794,8 +794,3 @@ export class Authenticator {
     }
   }
 }
-
-function stripTrailingSlash(input: string): string {
-  return input.replace(/\/$/, ''); // Remove trailing slash if it exists
-}
-


### PR DESCRIPTION
We have two seperate login paths: /and /admin

Because the redirect url does not contain the path, you can't use two seperate login flows at the moment.
By merging this PR cognito-at-edge will support this. I don't see any breaking changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.