### PR TITLE
Use 307 redirect when refreshing tokens in background to keep HTTP method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export class Authenticator {
    * @param  {String} location Path to redirection.
    * @return Lambda@Edge response.
    */
-  async _getRedirectResponse(tokens: Tokens, domain: string, location: string): Promise<CloudFrontResultResponse> {
+  async _getRedirectResponse(tokens: Tokens, domain: string, location: string, keepMethod: boolean = false): Promise<CloudFrontResultResponse> {
     const decoded = await this._jwtVerifier.verify(tokens.idToken as string);
     const username = decoded['cognito:username'] as string;
     const usernameBase = `${this._cookieBase}.${username}`;
@@ -309,7 +309,7 @@ export class Authenticator {
     }
 
     const response: CloudFrontResultResponse = {
-      status: '302' ,
+      status: keepMethod ? '307' : '302' ,
       headers: {
         'location': [{
           key: 'Location',
@@ -624,7 +624,7 @@ export class Authenticator {
         if (tokens.refreshToken) {
           this._logger.debug({ msg: 'Verifying idToken failed, verifying refresh token instead...', tokens, err });
           return await this._fetchTokensFromRefreshToken(redirectURI, tokens.refreshToken)
-            .then(tokens => this._getRedirectResponse(tokens, cfDomain, request.uri));
+            .then(tokens => this._getRedirectResponse(tokens, cfDomain, request.uri, true));
         } else {
           throw err;
         }


### PR DESCRIPTION
*Issue # (if available):* fixes #82

*Description of changes:*

When redirecting to cognito, or we handle a request that's been redirected from cognito we likely want to try GET on the target since a) cognito expects it or b) if we've taken a detour to cognito the original method is lost anyway.
However, when we've refreshed tokens in the background and use a redirect response to the same url that was requested to set cookies we want the original request to be retried with the same method as it was originally made with, this way background POST/PUT/etc requests from web apps will not fail on the first try where tokens are refreshed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.