### PR TITLE
chore: update axios to 1.6.5 to resolve npm audit alarm

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,7 @@ module.exports = {
       tsconfig: 'tsconfig.test.json',
     },
   },
+  moduleNameMapper: {
+    '^axios$': 'axios/dist/node/axios.cjs',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "aws-jwt-verify": "^2.1.1",
-    "axios": "^0.25.0",
+    "axios": "^1.6.5",
     "pino": "^8.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION

*Issue # (if available):*
N/A

*Description of changes:*

This PR bumps the version of axios up to 1.6.5 (i.e. the latest available), in order to resolve npm audit alarms for packages that need an update.

I've also added CJS mappings in to jest for axios config so the tests are able to run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.