### PR TITLE
Add support for custom cognito redirect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `disableCookieDomain` *boolean* (Optional) Sets domain attribute in cookies, defaults to false (eg: `false`)
   * `httpOnly` *boolean* (Optional) Forbids JavaScript from accessing the cookies, defaults to false (eg: `false`). Note, if this is set to `true`, the cookies will not be accessible to Amplify auth if you are using it client side.
   * `sameSite` *Strict | Lax | None* (Optional) Allows you to declare if your cookie should be restricted to a first-party or same-site context (eg: `SameSite=None`).
+  * `redirectPath` *string* (Optional) URI path used as redirect target after successful Cognito authentication (eg: `/oauth2/idpresponse`), defaults to the website root path. Needs to be a path that is handled by the library.
   * `cookiePath` *string* (Optional) Sets Path attribute in cookies
   * `cookieDomain` *string* (Optional) Sets the domain name used for the token cookies
   * `cookieSettingsOverrides` *object* (Optional) Cookie settings overrides for different token cookies -- idToken, accessToken and refreshToken

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `disableCookieDomain` *boolean* (Optional) Sets domain attribute in cookies, defaults to false (eg: `false`)
   * `httpOnly` *boolean* (Optional) Forbids JavaScript from accessing the cookies, defaults to false (eg: `false`). Note, if this is set to `true`, the cookies will not be accessible to Amplify auth if you are using it client side.
   * `sameSite` *Strict | Lax | None* (Optional) Allows you to declare if your cookie should be restricted to a first-party or same-site context (eg: `SameSite=None`).
-  * `redirectPath` *string* (Optional) URI path used as redirect target after successful Cognito authentication (eg: `/oauth2/idpresponse`), defaults to the website root path. Needs to be a path that is handled by the library.
+  * `parseAuthPath` *string* (Optional) URI path used as redirect target after successful Cognito authentication (eg: `/oauth2/idpresponse`), defaults to the web domain root. Needs to be a path that is handled by the library. When using this parameter, you should also provide a value for `cookiePath` to ensure your cookies are available for the right paths.
   * `cookiePath` *string* (Optional) Sets Path attribute in cookies
   * `cookieDomain` *string* (Optional) Sets the domain name used for the token cookies
   * `cookieSettingsOverrides` *object* (Optional) Cookie settings overrides for different token cookies -- idToken, accessToken and refreshToken
@@ -74,7 +74,6 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `logoutConfiguration` *object* (Optional) Enables logout functionality
     * `logoutUri` *string* URI path, which when matched with request, logs user out by revoking tokens and clearing cookies
     * `logoutRedirectUri` *string* The URI to which the user is redirected to after logging them out
-  * `parseAuthPath` *string* (Optional) URI path to use for the parse auth handler, when the library is used in an authentication gateway setup
   * `csrfProtection` *object* (Optional) Enables CSRF protection
     * `nonceSigningSecret` *string* Secret used for signing nonce cookies
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -722,6 +722,31 @@ describe('handle', () => {
       });
   });
 
+  test('should fetch and set token if code is present (custom redirect)', () => {
+    const authenticatorWithCustomRedirect : any = new Authenticator({
+      region: 'us-east-1',
+      userPoolId: 'us-east-1_abcdef123',
+      userPoolAppId: '123456789qwertyuiop987abcd',
+      userPoolDomain: 'my-cognito-domain.auth.us-east-1.amazoncognito.com',
+      parseAuthPath: '/custom/login/path',
+    });
+    jest.spyOn(authenticatorWithCustomRedirect._jwtVerifier, 'verify');
+    jest.spyOn(authenticatorWithCustomRedirect, '_fetchTokensFromCode');
+    jest.spyOn(authenticatorWithCustomRedirect, '_getRedirectResponse');
+    authenticatorWithCustomRedirect._jwtVerifier.verify.mockImplementationOnce(async () => { throw new Error(); });
+    authenticatorWithCustomRedirect._fetchTokensFromCode.mockResolvedValueOnce(tokenData);
+    authenticatorWithCustomRedirect._getRedirectResponse.mockReturnValueOnce({ response: 'toto' });
+    const request = getCloudfrontRequest();
+    request.Records[0].cf.request.querystring = 'code=54fe5f4e&state=/lol';
+    return expect(authenticatorWithCustomRedirect.handle(request)).resolves.toEqual({ response: 'toto' })
+      .then(() => {
+        expect(authenticatorWithCustomRedirect._jwtVerifier.verify).toHaveBeenCalled();
+        expect(authenticatorWithCustomRedirect._fetchTokensFromCode).toHaveBeenCalledWith('https://d111111abcdef8.cloudfront.net/custom/login/path', '54fe5f4e');
+        expect(authenticatorWithCustomRedirect._getRedirectResponse).toHaveBeenCalledWith(tokenData, 'd111111abcdef8.cloudfront.net', '/lol');
+      });
+  });
+
+
   test('should fetch and set token if code is present and when csrfProtection is enabled', () => {
     authenticator._jwtVerifier.verify.mockImplementationOnce(async () => { throw new Error(); });
     authenticator._fetchTokensFromCode.mockResolvedValueOnce(tokenData);
@@ -768,6 +793,40 @@ describe('handle', () => {
       });
   });
 
+  test('should redirect to auth domain if unauthenticated and no code (custom redirect)', () => {
+    const authenticatorWithCustomRedirect : any = new Authenticator({
+      region: 'us-east-1',
+      userPoolId: 'us-east-1_abcdef123',
+      userPoolAppId: '123456789qwertyuiop987abcd',
+      userPoolDomain: 'my-cognito-domain.auth.us-east-1.amazoncognito.com',
+      parseAuthPath: '/custom/login/path',
+    });
+    jest.spyOn(authenticatorWithCustomRedirect._jwtVerifier, 'verify');
+    authenticator._jwtVerifier.verify.mockImplementationOnce(async () => { throw new Error();});
+    return expect(authenticatorWithCustomRedirect.handle(getCloudfrontRequest())).resolves.toEqual(
+      {
+        status: '302',
+        headers: {
+          'location': [{
+            key: 'Location',
+            value: 'https://my-cognito-domain.auth.us-east-1.amazoncognito.com/authorize?redirect_uri=https://d111111abcdef8.cloudfront.net/custom/login/path&response_type=code&client_id=123456789qwertyuiop987abcd&state=/lol%3F%3Fparam%3D1',
+          }],
+          'cache-control': [{
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, max-age=0, must-revalidate',
+          }],
+          'pragma': [{
+            key: 'Pragma',
+            value: 'no-cache',
+          }],
+        },
+      },
+    )
+      .then(() => {
+        expect(authenticatorWithCustomRedirect._jwtVerifier.verify).toHaveBeenCalled();
+      });
+  });
+
   test('should redirect to auth domain and clear csrf cookies if unauthenticated and no code', async () => {
     authenticator._jwtVerifier.verify.mockImplementationOnce(async () => { throw new Error(); });
     authenticator._csrfProtection = {
@@ -804,12 +863,12 @@ describe('handle', () => {
   });
 
   test('should redirect to auth domain with custom return redirect if unauthenticated', async () => {
-    let authenticatorWithCustomRedirect : any = new Authenticator({
+    const authenticatorWithCustomRedirect : any = new Authenticator({
       region: 'us-east-1',
       userPoolId: 'us-east-1_abcdef123',
       userPoolAppId: '123456789qwertyuiop987abcd',
       userPoolDomain: 'my-cognito-domain.auth.us-east-1.amazoncognito.com',
-      redirectPath: '/custom/login/path',
+      parseAuthPath: '/custom/login/path',
     });
     jest.spyOn(authenticatorWithCustomRedirect._jwtVerifier, 'verify');
     authenticatorWithCustomRedirect._jwtVerifier.verify.mockImplementationOnce(async () => { throw new Error(); });


### PR DESCRIPTION
*Description of changes:*
We are using cognito-at-edge in an environment where not all paths are handled by our edge lambda. Specifically, the website root `/` is not handled by us.

Example:

* https://example.com/foo/* - handled by us
* https://example.com/ - not handled by us

An access attempt to https://example.com/foo/ results in a redirect to https://domain.auth.us-east-1.amazoncognito.com/authorize?redirect_uri=https://example.com&response_type=code&client_id=63gcbm2jmskokurt5ku9fhejc6&state=/foo/

Notice that the `redirect_uri` points to a path that is not handled by us.

This PR adds an option `redirectPath` to allow specifying a different value for `redirect_uri`. Example:
```
const authenticator = new Authenticator({
  region: 'us-east-1',
  userPoolId: 'us-east-1_tyo1a1FHH',
  userPoolAppId: '63gcbm2jmskokurt5ku9fhejc6',
  userPoolDomain: 'domain.auth.us-east-1.amazoncognito.com',
  redirectPath: '/foo/oauth2/idresponse',
});
```
An access attempt to https://example.com/foo/ now results in a redirect to https://domain.auth.us-east-1.amazoncognito.com/authorize?redirect_uri=https://example.com/foo/oauth2/idresponse&response_type=code&client_id=63gcbm2jmskokurt5ku9fhejc6&state=/foo/

I hope the use-case makes sense to you and isn't too much of an edge case. (Otherwise I'd love to learn of a way to get the same result without modifying or effectively forking cognito-at-edge.) I'd be more than happy to tweak the naming, add more automated tests, etc.

The modified code appears to work well and is already used in production.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.