### PR TITLE
allow customisation of the JWT fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `csrfProtection` *object* (Optional) Enables CSRF protection
     * `nonceSigningSecret` *string* Secret used for signing nonce cookies
   * `logLevel` *string* (Optional) Logging level. Default: `'silent'`. One of `'fatal'`, `'error'`, `'warn'`, `'info'`, `'debug'`, `'trace'` or `'silent'`.
+  * `jwtVerifierFetcherRequestOptions` *object* (Optional) Default: undefined. Use to override JwtVerifier fetcher request options, for example re-configuring the JWKS response timeout from the default 1500ms. The interface for request options adds one additional option to the Node.js standard RequestOptions, "responseTimeout", with which a timeout can be set within which the response must be received. (Note the "timeout" in the Node.js standard RequestOptions, concerns something else: the socket idle timeout). See https://github.com/awslabs/aws-jwt-verify#configuring-the-jwks-response-timeout-and-other-http-options-with-jsonfetcher for more information.
 
 *This is the class constructor.*
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import pino from 'pino';
 import { parse, stringify } from 'querystring';
 import { CookieAttributes, CookieSettingsOverrides, CookieType, Cookies, SAME_SITE_VALUES, SameSite, getCookieDomain } from './util/cookie';
 import { CSRFTokens, NONCE_COOKIE_NAME_SUFFIX, NONCE_HMAC_COOKIE_NAME_SUFFIX, PKCE_COOKIE_NAME_SUFFIX, generateCSRFTokens, signNonce, urlSafe } from './util/csrf';
+import { SimpleJsonFetcher } from 'aws-jwt-verify/https';
+import { SimpleJwksCache } from 'aws-jwt-verify/jwk';
 
 export interface AuthenticatorParams {
   region: string;
@@ -25,6 +27,7 @@ export interface AuthenticatorParams {
   csrfProtection?: {
     nonceSigningSecret: string;
   },
+  jwtVerifierFetcherRequestOptions?: SimpleJsonFetcher['defaultRequestOptions']
 }
 
 interface LogoutConfiguration {
@@ -59,6 +62,7 @@ export class Authenticator {
   _cookieSettingsOverrides?: CookieSettingsOverrides;
   _logger;
   _jwtVerifier;
+  _jwtVerifierFetcherRequestOptions?: AuthenticatorParams['jwtVerifierFetcherRequestOptions'] = undefined
 
   constructor(params: AuthenticatorParams) {
     this._verifyParams(params);
@@ -83,7 +87,15 @@ export class Authenticator {
       userPoolId: params.userPoolId,
       clientId: params.userPoolAppId,
       tokenUse: 'id',
-    });
+    },
+    {
+      jwksCache: new SimpleJwksCache({
+        fetcher: new SimpleJsonFetcher({
+          defaultRequestOptions: this._jwtVerifierFetcherRequestOptions,
+        }),
+      }),
+    }
+    );
     this._csrfProtection = params.csrfProtection;
     this._logoutConfiguration = params.logoutConfiguration;
     this._parseAuthPath = (params.parseAuthPath || '').replace(/^\//, '');
@@ -792,4 +804,3 @@ export class Authenticator {
     }
   }
 }
-


### PR DESCRIPTION
*Issue #86* 

*Description of changes:*

Allows customisation of the JWT fetcher. Mainly desired so that the 1500ms default responseTimeout can be increased to 5000ms, which has been the source of this issue #86. I have forked this repo and deployed the changes with a 5000ms to my lambda@edge and now the cognito flow and redirection works as expected, whereas previously I was getting timeout errors, the source of which was verifying the JWT. 

Its effecteively just allowing this https://github.com/awslabs/aws-jwt-verify#configuring-the-jwks-response-timeout-and-other-http-options-with-jsonfetcher

Some related issues that I found useful: https://github.com/awslabs/aws-jwt-verify/issues/133 and in particular https://github.com/awslabs/aws-jwt-verify/issues/72

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.