### PR TITLE
fix logout behaviour

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -538,7 +538,7 @@ export class Authenticator {
       state = csrfTokens.state;
     }
 
-    const userPoolUrl = `https://${this._userPoolDomain}/authorize?redirect_uri=${redirectURI}&response_type=code&client_id=${this._userPoolAppId}&state=${state}`;
+    const userPoolUrl = `https://${this._userPoolDomain}/login?redirect_uri=${redirectURI}&response_type=code&client_id=${this._userPoolAppId}&state=${state}`;
 
     this._logger.debug(`Redirecting user to Cognito User Pool URL ${userPoolUrl}`);
   


### PR DESCRIPTION
*Issue # (if available):*

When calling logoutUri, we get redirected to logoutRedirectUri, but on a subsequent request to parseAuthPath, we land on a protected page as if we were never logged out.
This happens because the logout call does not clear the cookies for the AWS Cognito domain (userPoolDomain).
This is expected behavior, since we cannot manage cookies for an external domain (like Cognito’s) from Lambda@Edge.

*Description of changes:*

Since the cookies for the userPoolDomain remain, when we access a protected page again, AWS Cognito transparently lets us through without prompting for login and password.
Switching the URI from authorize to login allows Cognito to explicitly ask the user—after logout—whether they want to use the saved session or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.