### PR TITLE
Fix maintain refresh token flow querystring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -617,7 +617,7 @@ export class Authenticator {
         if (tokens.refreshToken) {
           this._logger.debug({ msg: 'Verifying idToken failed, verifying refresh token instead...', tokens, err });
           return await this._fetchTokensFromRefreshToken(redirectURI, tokens.refreshToken)
-            .then(tokens => this._getRedirectResponse(tokens, cfDomain, request.uri));
+            .then(tokens => this._getRedirectResponse(tokens, cfDomain, request.querystring ? `${request.uri}?${request.querystring}` : request.uri));
         } else {
           throw err;
         }


### PR DESCRIPTION
*Issue # (if available):*

fixes #75 , fixes #110 

*Description of changes:*

- Updated the refresh token flow to preserve the request.querystring.
- Added corresponding test cases. Also, modified existing test cases to remove the leading '?' from the request.querystring (as it was causing duplication like '??').

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.