### PR TITLE
Add language parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For an explanation of the interactions between CloudFront, Cognito and Lambda@Ed
   * `userPoolAppId` *string* Cognito UserPool Application ID (eg: `63gcbm2jmskokurt5ku9fhejc6`)
   * `userPoolAppSecret` *string* (Optional) Cognito UserPool Application Secret (eg: `oh470px2i0uvy4i2ha6sju0vxe4ata9ol3m63ufhs2t8yytwjn7p`)
   * `userPoolDomain` *string* Cognito UserPool domain (eg: `your-domain.auth.us-east-1.amazoncognito.com`)
+  * `language` *string* (Optional) Language code for Cognito managed login UI (eg: `ja`). Supported languages: `de` (German), `en` (English), `es` (Spanish), `fr` (French), `id` (Bahasa Indonesia), `it` (Italian), `ja` (Japanese), `ko` (Korean), `pt-BR` (Portuguese - Brazil), `zh-CN` (Simplified Chinese), `zh-TW` (Traditional Chinese).
   * `cookieExpirationDays` *number* (Optional) Number of day to set cookies expiration date, default to 365 days (eg: `365`). It's recommended to set this value to match `refreshTokenValidity` parameter of the pool client.
   * `disableCookieDomain` *boolean* (Optional) Sets domain attribute in cookies, defaults to false (eg: `false`)
   * `httpOnly` *boolean* (Optional) Forbids JavaScript from accessing the cookies, defaults to false (eg: `false`). Note, if this is set to `true`, the cookies will not be accessible to Amplify auth if you are using it client side.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -637,6 +637,39 @@ describe('createAuthenticator', () => {
     params.logoutConfiguration = { logoutUri: '/' };
     expect(() => new Authenticator(params)).toThrow('logoutUri');
   });
+
+  test('should create authenticator with valid language', () => {
+    params.language = 'ja';
+    expect(typeof new Authenticator(params)).toBe('object');
+  });
+
+  test('should create authenticator without language parameter', () => {
+    expect(typeof new Authenticator(params)).toBe('object');
+  });
+
+  test('should create authenticator with all supported languages', () => {
+    const supportedLanguages = ['de', 'en', 'es', 'fr', 'id', 'it', 'ja', 'ko', 'pt-BR', 'zh-CN', 'zh-TW'];
+
+    supportedLanguages.forEach(lang => {
+      params.language = lang;
+      expect(() => new Authenticator(params)).not.toThrow();
+    });
+  });
+
+  test('should throw error for invalid language', () => {
+    params.language = 'invalid-lang';
+    expect(() => new Authenticator(params)).toThrow('Expected params.language to be one of: de, en, es, fr, id, it, ja, ko, pt-BR, zh-CN, zh-TW');
+  });
+
+  test('should throw error for empty string language', () => {
+    params.language = '';
+    expect(() => new Authenticator(params)).toThrow('Expected params.language to be one of: de, en, es, fr, id, it, ja, ko, pt-BR, zh-CN, zh-TW');
+  });
+
+  test('should throw error for non-string language', () => {
+    params.language = 123; // number instead of string
+    expect(() => new Authenticator(params)).toThrow('Expected params.language to be one of: de, en, es, fr, id, it, ja, ko, pt-BR, zh-CN, zh-TW');
+  });
 });
 
 describe('handle', () => {


### PR DESCRIPTION
*Issue # (if available):*

*Description of changes:*

Added a `language` option to the Authenticator, allowing users to specify the language when redirecting to the Cognito managed login page.  
The selected language is appended as a `lang` query parameter in the redirect URL.

The `SUPPORTED_LANGUAGES` constant, which defines the available languages for this option, was created with reference to the official documentation:  
https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-managed-login.html#managed-login-localization

Example usage:
```ts
const authenticator = new Authenticator({
  region: 'us-east-1',
  userPoolId: 'us-east-1_abcdef123',
  userPoolAppId: '123456789qwertyuiop987abcd',
  userPoolDomain: 'my-cognito-domain.auth.us-east-1.amazoncognito.com',
  language: 'ja',
});
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.